### PR TITLE
Bump version number to 1.1

### DIFF
--- a/appengine.php
+++ b/appengine.php
@@ -3,7 +3,7 @@
 Plugin Name: Google App Engine for WordPress
 Plugin URI: http://developers.google.com/appengine/
 Description: Optimize your WordPress installation for Google App Engine
-Version: 1.0
+Version: 1.1
 Author: Google
 Author URI: http://developers.google.com/appengine/
 License: GPL2


### PR DESCRIPTION
Bump version number to 1.1 to reflect WordPress.org repo.
