### PR TITLE
Update readme.txt with GAE only warning

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,7 @@ This plugin adds overrides to core functionality in WordPress to use App Engine
 infrastructure, such as the Mail functionality, and uploading media to Google
 Cloud Storage
 
+= Note: This plugin is designed to be used with Google App Engine only and will not work with any other hosting. = 
 
 == Installation ==
 


### PR DESCRIPTION
Although this was fixed here https://github.com/GoogleCloudPlatform/appengine-wordpress-plugin/commit/d748edbb6b6a4339078030a2edd75779b1ee6abb#diff-b2bf9bbf2fcc0aab26e7ae461a373b41R450, I feel it is worth adding this warning given it's the most frequent question about the plugin.
