### PR TITLE
Update to make uploads in 4.0 work correctly

### DIFF
--- a/modules/uploads.php
+++ b/modules/uploads.php
@@ -192,8 +192,8 @@ class Uploads {
 		$auth_cookie      = wp_generate_auth_cookie( $user_id, $expiration, $scheme );
 		$logged_in_cookie = wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' );
 
-		$_COOKIE[$auth_cookie_name] = $auth_cookie;
-		$_COOKIE[LOGGED_IN_COOKIE]  = $logged_in_cookie;
+		if ( !isset($_COOKIE[$auth_cookie_name]) ) $_COOKIE[$auth_cookie_name] = $auth_cookie;
+		if ( !isset($_COOKIE[LOGGED_IN_COOKIE]) ) $_COOKIE[LOGGED_IN_COOKIE] = $logged_in_cookie;
 	}
 
 	/**


### PR DESCRIPTION
In 4.0 the media uploads fail due to an issue with the cookies

See https://wordpress.org/support/topic/upload-fails-with-http-error?replies=9

This is the solution, I believe, for this issue:

https://github.com/GoogleCloudPlatform/appengine-wordpress-plugin/issues/16
