### PR TITLE
Support Multisite by custom activation logic to set the default GCS bucket

### DIFF
--- a/appengine.php
+++ b/appengine.php
@@ -54,8 +54,16 @@ function is_development() {
  *
  * This just calls the action to allow the modules to act independently.
  */
-function activation() {
-	do_action( 'appengine_activation' );
+function activation($blog_id=null) {
+
+    if (!$blog_id) {
+        $blog_id = get_current_blog_id();
+    }
+
+    // support multisite by passing the new blog_id
+    // this allows modules to switch_to_blog($blog_id)
+    // before doing their jobs if needed
+	do_action( 'appengine_activation', $blog_id );
 }
 
 // Load the App Engine modules
@@ -82,10 +90,6 @@ if ( !is_multisite() ) {
 } else {
     // network installs do not run activation hooks so
     // we have to manually call our activation routine
-    // and guard that it only happens once
-    $option_name = 'appengine_activated';
-    if ( !get_option( $option_name ) ) {
-        activation();
-        add_option( $option_name, '1' );
-    }
+    // whenever a new blog is created
+    add_action( 'wpmu_new_blog',  __NAMESPACE__ . '\\activation', 10, 1 );
 }

--- a/appengine.php
+++ b/appengine.php
@@ -76,4 +76,16 @@ if ( $modules_dir = @ opendir( __DIR__ . '/modules/' ) ) {
 // Include the App Engine specific WordPress importer.
 require_once __DIR__ . '/importer/wordpress-importer.php';
 
-register_activation_hook( __FILE__, __NAMESPACE__ . '\\activation' );
+// Activation hook for non-network installs
+if ( !is_multisite() ) {
+    register_activation_hook( __FILE__, __NAMESPACE__ . '\\activation' );
+} else {
+    // network installs do not run activation hooks so
+    // we have to manually call our activation routine
+    // and guard that it only happens once
+    $option_name = 'appengine_activated';
+    if ( !get_option( $option_name ) ) {
+        activation();
+        add_option( $option_name, '1' );
+    }
+}

--- a/modules/uploads.php
+++ b/modules/uploads.php
@@ -567,7 +567,7 @@ class Editor extends WP_Image_Editor_GD {
 class Admin {
 	public static function bootstrap(){
 		add_action( 'appengine_register_settings', __CLASS__ . '::register_google_settings' );
-		add_action( 'appengine_activation', __CLASS__ . '::set_default_bucket' );
+		add_filter( 'default_option_appengine_uploads_bucket', __CLASS__ . '::filter_upload_default_bucket' );
 	}
 
 	public static function register_google_settings() {
@@ -668,22 +668,25 @@ class Admin {
 		return $input;
 	}
 
-	public static function set_default_bucket() {
-		$current = get_option( 'appengine_uploads_bucket', false );
-		if ( ! empty( $current ) ) {
-			return;
-		}
-
-		$default = CloudStorageTools::getDefaultGoogleStorageBucketName();
-		update_option( 'appengine_uploads_bucket', $default );
-	}
+    /**
+     * Filter get_option('appengine_uploads_bucket') when the value is not set
+     *
+     * @param mixed $default
+     * @return string
+     */
+	public static function filter_upload_default_bucket( $default ) {
+      if (!strlen($default)) {
+        return CloudStorageTools::getDefaultGoogleStorageBucketName();
+      }
+      return $default;
+    }
 
   /**
    * Workaround for Windows bug in is_writable() function
    *
    * @since 2.8.0
    *
-   * @param string $path
+   * @param string $bucket
    * @return bool
    */
   public static function bucket_is_writable( $bucket ) {


### PR DESCRIPTION
This plugin sets the default GCS bucket on activation via an action registered via `register_activation_hook`. `register_activation_hook` is not called in Network installs of wordpress or for mu-plugins.

This pull request uses an installation guard via `get_option` and `add_option` to make sure it only runs once for each blog.
