### PR TITLE
Silence undefined variable warnings when uploading

### DIFF
--- a/modules/uploads.php
+++ b/modules/uploads.php
@@ -395,9 +395,9 @@ class Uploads {
 		// since in the development context getPublicUrl() is currently used to
 		// generate the URL.
 		if (self::is_production()) {
-			if ( ! is_null( $options['size'] ) ) {
+			if ( ! empty( $options['size'] ) ) {
 				$url .= ( '=s' . $options['size'] );
-				if ( $options['crop'] ) {
+				if ( isset($options['crop']) ) {
 					$url .= '-c';
 				}
 			}


### PR DESCRIPTION
When uploading a file if `size` was not set then it would output a warning in the response. This caused the JSON response to be invalid and thus fail parsing.
