### PR TITLE
Updated the readme because we'll bundle the vendor dir.

### DIFF
--- a/gcs-media-plugin/composer.json
+++ b/gcs-media-plugin/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/cloud": "^0.21"
+        "google/cloud": "~0.21.1"
     }
 }

--- a/gcs-media-plugin/composer.lock
+++ b/gcs-media-plugin/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b9b0200fad71d46464b077d4d9c80dbf",
-    "content-hash": "76cb1ef2d63b407fed71c455ed599b4a",
+    "hash": "17ee24b8d26980bb2c7f2893e0ef8e2c",
+    "content-hash": "20c51974495e4b9f6ef6132dc5741ea0",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -100,16 +100,16 @@
         },
         {
             "name": "google/cloud",
-            "version": "v0.21.0",
+            "version": "v0.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GoogleCloudPlatform/google-cloud-php.git",
-                "reference": "a7bac23c526a5920134d909af80fcba4976276e1"
+                "reference": "68bbbc030c256bc30f9adfab1830eb6e462a0958"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php/zipball/a7bac23c526a5920134d909af80fcba4976276e1",
-                "reference": "a7bac23c526a5920134d909af80fcba4976276e1",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php/zipball/68bbbc030c256bc30f9adfab1830eb6e462a0958",
+                "reference": "68bbbc030c256bc30f9adfab1830eb6e462a0958",
                 "shasum": ""
             },
             "require": {
@@ -183,7 +183,7 @@
                 "translation",
                 "vision"
             ],
-            "time": "2017-02-22 20:25:16"
+            "time": "2017-02-23 20:14:16"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/gcs-media-plugin/gcs.php
+++ b/gcs-media-plugin/gcs.php
@@ -3,7 +3,7 @@
 Plugin Name: Google Cloud Storage plugin
 Plugin URI:  http://wordpress.org/plugins/gcs/
 Description: A plugin for uploading media files to Google Cloud Storage
-Version:     0.1
+Version:     0.1.1
 Author:      Google Inc
 Author URI:  http://cloud.google.com/
 License:     GPL2

--- a/gcs-media-plugin/gcs.php
+++ b/gcs-media-plugin/gcs.php
@@ -30,6 +30,11 @@ Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 namespace Google\Cloud\Storage\WordPress;
 
+require_once __DIR__ . '/vendor/autoload.php';
+
+$storageClient = new \Google\Cloud\Storage\StorageClient();
+$storageClient->registerStreamWrapper();
+
 define(__NAMESPACE__ . '\\PLUGIN_DIR', __DIR__);
 define(__NAMESPACE__ . '\\PLUGIN_PATH', __FILE__);
 

--- a/gcs-media-plugin/readme.txt
+++ b/gcs-media-plugin/readme.txt
@@ -17,26 +17,7 @@ Google Cloud Storage bucket.
 == Installation ==
 
 This plugin should be downloaded and placed in your
-`/wp-content/plugins/` directory. Also this plugin depends on
-google/cloud packagist package, and you need to install the gs://
-stream wrapper.
-
-First install the Google Cloud library by the following command:
-
-```sh
-$ composer require google/cloud
-```
-
-Add the following lines to your `wp-config.php`:
-
-```php
-// Adjust the path as needed
-require_once __DIR__ . '/../vendor/autoload.php';
-
-$storageClient = new Google\Cloud\Storage\StorageClient();
-$storageClient->registerStreamWrapper();
-
-```
+`/wp-content/plugins/` directory.
 
 Then enable this plugin on the WordPress admin UI, and configure your
 Google Cloud Storage bucket in the plugin setting UI. You need to set
@@ -46,6 +27,9 @@ After the configuration, media files will be uploaded to Google Cloud
 Storage and served from there.
 
 == Changelog ==
+
+= 0.1.1 =
+* Bundle vendor dir in the zip file
 
 = 0.1 =
 * Initial release


### PR DESCRIPTION
Update to google/cloud 0.21.1
Update the version to 0.1.1

The WordPress plugin reviewer requested me to bundle the vendor dir in the zip file. I don't like bundling, but it's the only way to publish on their plugin directory.