### PR TITLE
lowercase contributor "google" to match the wordpress.org

### DIFF
--- a/gcs-media-plugin/readme.txt
+++ b/gcs-media-plugin/readme.txt
@@ -1,5 +1,5 @@
 === Google Cloud Storage plugin ===
-Contributors: Google
+Contributors: google
 Tags: google, Google Cloud Storage
 Requires at least: 3
 Stable tag: 0.1.3


### PR DESCRIPTION
See https://plugins.trac.wordpress.org/browser/google-app-engine/trunk/readme.txt