### PR TITLE
Verify AppIdentityService signatures against all valid certificates

### DIFF
--- a/appengine-plugin/modules/uploads.php
+++ b/appengine-plugin/modules/uploads.php
@@ -148,14 +148,12 @@ class Uploads {
 			return $user;
 		}
 
-		$user_id     = absint( $_GET['gae_auth_user'] );
-		$sign_result = self::sign_auth_key( AUTH_KEY . $user_id );
+		$user_id             = absint( $_GET['gae_auth_user'] );
+		$key_name            = $_GET['gae_auth_key'];
+		$string_to_verify    = AUTH_KEY . $user_id;
+		$signature_to_verify = base64_decode($_GET['gae_auth_signature']);
 
-		if ( $sign_result['key_name'] !== $_GET['gae_auth_key'] ) {
-			return $user;
-		}
-
-		if ( base64_decode( $_GET['gae_auth_signature'] ) !== $sign_result['signature'] ) {
+		if (self::verify_signed_auth_key($key_name, $string_to_verify, $signature_to_verify) !== true) {
 			return $user;
 		}
 
@@ -486,6 +484,34 @@ class Uploads {
       ];
     }
   }
+
+	private static function verify_signed_auth_key($key_name, $string_to_verify, $signature_to_verify) {
+		if (self::is_production()) {
+
+			# get list of all valid certificates for GAE project
+			$public_certificates = AppIdentityService::getPublicCertificates();
+
+			# find certificate with matching key name
+			foreach ($public_certificates as $cert) {
+				if ($cert->getCertificateName() === $key_name) {
+
+					# extract public key from X509 certificate
+					$public_key = openssl_pkey_get_public($cert->getX509CertificateInPemFormat());
+
+					# verify the signed data, return true or false
+					return (openssl_verify($string_to_verify, $signature_to_verify, $public_key, "sha256") === 1);
+				}
+			}
+
+			# if no matching certificate, verification fails
+			return false;
+
+		} else {
+			// In the development server we are not concerned with trying to generate
+			// a secure signature.
+			return (sha1($string_to_verify) === $signature_to_verify);
+		}
+	}
 
 	public static function custom_image_editor( $editors ) {
 		$editors = [ __NAMESPACE__ . '\\Editor' ] + $editors;


### PR DESCRIPTION
[Background]
The `appengine-plugin` in this repo overrides the built-in uploading functionality of WordPress to use a GCS bucket for the WP media library storage backend. The plugin implements an authentication method using the AppIdentityService::signForApp() method to generate a signature using the GAE project's private keys, and verifies media uploads with these signatures being passed via a query string argument.

[Issue]
The authentication method currently verifies the signatures in each media upload by generating the same data to be signed, calling signForApp() and signing it, and comparing the user-provided signature against the one it generates for the request. However, this incorrectly assumes that the generated signature will be the same every time. Since GAE projects can sometimes have more than 1 private key, there can be multiple valid signatures, so this causes the authentication method to randomly fail. As a result, when a user uploads multiple media files, the uploads will fail and the user will get logged out of the WP admin panel.

To quote the AppIdentityService PHP documentation: "Since private keys are rotated periodically, getPublicCertificates() could return a list of public certificates. It's the caller's responsibility to try these certificates one by one when doing signature verification."

[Fix]
This pull request modifies the authentication method to verify a given signature against the correct key.
