### PR TITLE
Adds wordpress info headers to storage client API calls

### DIFF
--- a/gcs-media-plugin/composer.lock
+++ b/gcs-media-plugin/composer.lock
@@ -57,12 +57,12 @@
             "version": "v1.3.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/google/google-auth-library-php.git",
+                "url": "https://github.com/googleapis/google-auth-library-php.git",
                 "reference": "af72b3f50420c801dc35cc07b1fa429ae027b847"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/google/google-auth-library-php/zipball/af72b3f50420c801dc35cc07b1fa429ae027b847",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/af72b3f50420c801dc35cc07b1fa429ae027b847",
                 "reference": "af72b3f50420c801dc35cc07b1fa429ae027b847",
                 "shasum": ""
             },
@@ -104,12 +104,12 @@
             "version": "v1.23.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/GoogleCloudPlatform/google-cloud-php-core.git",
+                "url": "https://github.com/googleapis/google-cloud-php-core.git",
                 "reference": "44b3bb512a7a445bd4ecafbdc86ed7c142e58f9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php-core/zipball/44b3bb512a7a445bd4ecafbdc86ed7c142e58f9f",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/44b3bb512a7a445bd4ecafbdc86ed7c142e58f9f",
                 "reference": "44b3bb512a7a445bd4ecafbdc86ed7c142e58f9f",
                 "shasum": ""
             },
@@ -160,16 +160,16 @@
         },
         {
             "name": "google/cloud-storage",
-            "version": "v1.7.1",
+            "version": "v1.9.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/GoogleCloudPlatform/google-cloud-php-storage.git",
-                "reference": "5ee955f9e19984659ec74ba2331841a53bca3c13"
+                "url": "https://github.com/googleapis/google-cloud-php-storage.git",
+                "reference": "3d4787335fbdcae02df3be4918d17184027f3159"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/google-cloud-php-storage/zipball/5ee955f9e19984659ec74ba2331841a53bca3c13",
-                "reference": "5ee955f9e19984659ec74ba2331841a53bca3c13",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-storage/zipball/3d4787335fbdcae02df3be4918d17184027f3159",
+                "reference": "3d4787335fbdcae02df3be4918d17184027f3159",
                 "shasum": ""
             },
             "require": {
@@ -191,7 +191,7 @@
             "extra": {
                 "component": {
                     "id": "cloud-storage",
-                    "target": "GoogleCloudPlatform/google-cloud-php-storage.git",
+                    "target": "googleapis/google-cloud-php-storage.git",
                     "path": "Storage",
                     "entry": "src/StorageClient.php"
                 }
@@ -206,7 +206,7 @@
                 "Apache-2.0"
             ],
             "description": "Cloud Storage Client for PHP",
-            "time": "2018-08-20T17:02:50+00:00"
+            "time": "2018-11-27T19:21:13+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/gcs-media-plugin/gcs.php
+++ b/gcs-media-plugin/gcs.php
@@ -115,10 +115,13 @@ function register_settings()
 
 /**
  * Returns a configured instance of the Google Cloud Storage API client.
+ *
+ * @param callable $httpHandler [optional] Http Handler to invoke the API call.
  * @return StorageClient
  */
-function get_google_storage_client($httpHandler = null)
+function get_google_storage_client(callable $httpHandler = null)
 {
+    $httpHandler = $httpHandler ?: HttpHandlerFactory::build();
     return new StorageClient([
         'httpHandler' => function ($request, $options) use ($httpHandler) {
             $xGoogApiClientHeader = $request->getHeaderLine('x-goog-api-client');
@@ -128,10 +131,7 @@ function get_google_storage_client($httpHandler = null)
             );
 
             // Call default HTTP handler
-            return call_user_func_array(
-                $httpHandler ?: HttpHandlerFactory::build(),
-                [$request, $options]
-            );
+            return call_user_func_array($httpHandler, [$request, $options]);
         },
         'authHttpHandler' => HttpHandlerFactory::build(),
     ]);
@@ -144,11 +144,8 @@ function get_google_storage_client($httpHandler = null)
 function get_wp_info_header()
 {
     global $wp_version;
-    return sprintf(
-        'wp-gcs/%s wp/%s',
-        PLUGIN_VERSION,
-        $wp_version
-    );
+
+    return sprintf('wp-gcs/%s wp/%s', PLUGIN_VERSION, $wp_version);
 }
 
 register_activation_hook(__FILE__, __NAMESPACE__ . '\\activation_hook');

--- a/gcs-media-plugin/gcs.php
+++ b/gcs-media-plugin/gcs.php
@@ -3,7 +3,7 @@
 Plugin Name: Google Cloud Storage plugin
 Plugin URI:  http://wordpress.org/plugins/gcs/
 Description: A plugin for uploading media files to Google Cloud Storage
-Version:     0.1.3
+Version:     0.1.5
 Author:      Google Inc
 Author URI:  http://cloud.google.com/
 License:     GPL2
@@ -32,11 +32,20 @@ namespace Google\Cloud\Storage\WordPress;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$storageClient = new \Google\Cloud\Storage\StorageClient();
-$storageClient->registerStreamWrapper();
+use Google\Cloud\Storage\StorageClient;
 
 define(__NAMESPACE__ . '\\PLUGIN_DIR', __DIR__);
 define(__NAMESPACE__ . '\\PLUGIN_PATH', __FILE__);
+define(__NAMESPACE__ . '\\PLUGIN_VERSION', '0.1.5');
+
+$storageClient = new StorageClient([
+    'restOptions' => [
+        'headers' => [
+            'x-goog-api-client' => get_google_api_client_header(),
+        ]
+    ]
+]);
+$storageClient->registerStreamWrapper();
 
 /**
  * Render the options page.
@@ -107,6 +116,22 @@ function settings_link($links, $file)
 function register_settings()
 {
     do_action('gcs_register_settings');
+}
+
+/**
+ * Get the current "x-goog-api-client" string containing plugin and WordPress
+ * versions.
+ */
+function get_google_api_client_header()
+{
+    global $wp_version;
+    return sprintf(
+        'gl-php/%s gccl/%s wp-gcs/%s wp/%s',
+        PHP_VERSION,
+        StorageClient::VERSION,
+        PLUGIN_VERSION,
+        $wp_version
+    );
 }
 
 register_activation_hook(__FILE__, __NAMESPACE__ . '\\activation_hook');

--- a/gcs-media-plugin/gcs.php
+++ b/gcs-media-plugin/gcs.php
@@ -120,7 +120,7 @@ function register_settings()
 function get_google_storage_client($httpHandler = null)
 {
     return new StorageClient([
-        'httpHandler' => function($request, $options) use ($httpHandler) {
+        'httpHandler' => function ($request, $options) use ($httpHandler) {
             $xGoogApiClientHeader = $request->getHeaderLine('x-goog-api-client');
             $request = $request->withHeader(
                 'x-goog-api-client',

--- a/gcs-media-plugin/readme.txt
+++ b/gcs-media-plugin/readme.txt
@@ -2,7 +2,7 @@
 Contributors: google
 Tags: google, Google Cloud Storage
 Requires at least: 3
-Stable tag: 0.1.4
+Stable tag: 0.1.5
 Tested up to: 4.8
 Requires PHP: 5.5
 License: GPLv2 or later

--- a/gcs-media-plugin/tests/test-gcs.php
+++ b/gcs-media-plugin/tests/test-gcs.php
@@ -17,6 +17,8 @@
 
 namespace Google\Cloud\Storage\WordPress\Test;
 
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\Storage\WordPress;
 use Google\Cloud\Storage\WordPress\Uploads\Uploads;
 
 /**
@@ -32,7 +34,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
     {
         // Nothing for normal user
         ob_start();
-        \Google\Cloud\Storage\WordPress\options_page_view();
+        WordPress\options_page_view();
         $html = ob_get_clean();
         $this->assertEmpty($html);
 
@@ -42,7 +44,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
         );
         \wp_set_current_user($user_id);
         ob_start();
-        \Google\Cloud\Storage\WordPress\options_page_view();
+        WordPress\options_page_view();
         $html = ob_get_clean();
         $this->assertRegexp('/form action="options.php"/', $html);
     }
@@ -53,7 +55,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
     public function test_options_page()
     {
         // TODO: actually check the side effect of this call.
-        \Google\Cloud\Storage\WordPress\options_page();
+        WordPress\options_page();
     }
 
     /**
@@ -62,7 +64,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
     public function test_activation_hook()
     {
         // TODO: actually check the side effect of this call.
-        \Google\Cloud\Storage\WordPress\activation_hook();
+        WordPress\activation_hook();
     }
 
     /**
@@ -71,9 +73,9 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
     public function test_settings_link()
     {
         $links = [];
-        $links = \Google\Cloud\Storage\WordPress\settings_link(
+        $links = WordPress\settings_link(
             $links,
-            \plugin_basename(\Google\Cloud\Storage\WordPress\PLUGIN_PATH)
+            \plugin_basename(WordPress\PLUGIN_PATH)
         );
         $this->assertRegexp('/options-general.php\\?page=gcs/', $links[0]);
     }
@@ -87,7 +89,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
         $ssl = get_option(Uploads::USE_HTTPS_OPTION);
         $this->assertFalse($ssl);
         // We have the option set to true (1).
-        \Google\Cloud\Storage\WordPress\register_settings();
+        WordPress\register_settings();
         $ssl = get_option(Uploads::USE_HTTPS_OPTION);
         $this->assertEquals(1, $ssl);
     }
@@ -111,7 +113,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
      */
     public function test_filter_upload_dir()
     {
-        \Google\Cloud\Storage\WordPress\register_settings();
+        WordPress\register_settings();
         // It does nothing without setting the option.
         $values = array();
         $values = Uploads::filter_upload_dir($values);
@@ -212,7 +214,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
             $this->markTestSkipped('TEST_BUCKET envvar is not set');
         }
         $req = null;
-        $storage = \Google\Cloud\Storage\WordPress\get_google_storage_client(
+        $storage = WordPress\get_google_storage_client(
             function ($request, $options) use (&$req) {
                 // Store request in local variable for testing
                 $req = $request;
@@ -237,10 +239,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
         $this->assertArrayHasKey('gl-php', $headerValues);
         $this->assertEquals(PHP_VERSION, $headerValues['gl-php']);
         $this->assertArrayHasKey('gccl', $headerValues);
-        $this->assertEquals(
-            \Google\Cloud\Storage\StorageClient::VERSION,
-            $headerValues['gccl']
-        );
+        $this->assertEquals(StorageClient::VERSION, $headerValues['gccl']);
         $this->assertArrayHasKey('wp', $headerValues);
         $this->assertArrayHasKey('wp-gcs', $headerValues);
     }
@@ -250,17 +249,14 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
      */
     public function test_get_wp_info_header()
     {
-        $header = \Google\Cloud\Storage\WordPress\get_wp_info_header();
+        $header = WordPress\get_wp_info_header();
         $headerValues = $this->splitInfoHeader($header);
         $this->assertEquals(2, count($headerValues));
         $this->assertArrayHasKey('wp', $headerValues);
         global $wp_version;
         $this->assertEquals($wp_version, $headerValues['wp']);
         $this->assertArrayHasKey('wp-gcs', $headerValues);
-        $this->assertEquals(
-            \Google\Cloud\Storage\WordPress\PLUGIN_VERSION,
-            $headerValues['wp-gcs']
-        );
+        $this->assertEquals(WordPress\PLUGIN_VERSION, $headerValues['wp-gcs']);
     }
 
     private function splitInfoHeader($header)

--- a/gcs-media-plugin/tests/test-gcs.php
+++ b/gcs-media-plugin/tests/test-gcs.php
@@ -207,7 +207,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
      */
     public function test_get_google_api_client_header()
     {
-        $header = \Google\Cloud\Storage\WordPress\register_settings();
+        $header = \Google\Cloud\Storage\WordPress\get_google_api_client_header();
         $headerValues = [];
         foreach(explode(' ', $header) as $part) {
             list($key, $val) = explode('/', $part);

--- a/gcs-media-plugin/tests/test-gcs.php
+++ b/gcs-media-plugin/tests/test-gcs.php
@@ -209,7 +209,7 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
     {
         $header = \Google\Cloud\Storage\WordPress\get_google_api_client_header();
         $headerValues = [];
-        foreach(explode(' ', $header) as $part) {
+        foreach (explode(' ', $header) as $part) {
             list($key, $val) = explode('/', $part);
             $headerValues[$key] = $val;
         }

--- a/gcs-media-plugin/tests/test-gcs.php
+++ b/gcs-media-plugin/tests/test-gcs.php
@@ -201,4 +201,29 @@ class GcsPluginUnitTestCase extends \WP_UnitTestCase
         $result = Uploads::validate_use_https(1);
         $this->assertTrue($result);
     }
+
+    /**
+     * A test for validate_use_https.
+     */
+    public function test_get_google_api_client_header()
+    {
+        $header = \Google\Cloud\Storage\WordPress\register_settings();
+        $headerValues = [];
+        foreach(explode(' ', $header) as $part) {
+            list($key, $val) = explode('/', $part);
+            $headerValues[$key] = $val;
+        }
+        $this->assertEquals(4, count($headerValues));
+        $this->assertArrayHasKey('gl-php', $headerValues);
+        $this->assertEquals(PHP_VERSION, $headerValues['gl-php']);
+        $this->assertArrayHasKey('gccl', $headerValues);
+        $this->assertArrayHasKey('wp', $headerValues);
+        global $wp_version;
+        $this->assertEquals($wp_version, $headerValues['wp']);
+        $this->assertArrayHasKey('wp-gcs', $headerValues);
+        $this->assertEquals(
+            \Google\Cloud\Storage\WordPress\PLUGIN_VERSION,
+            $headerValues['wp-gcs']
+        );
+    }
 }


### PR DESCRIPTION
- Updates plugin version to `0.1.5`
- Adds WordPress info to storage client `x-goog-api-client` header
- Updates `google/cloud-storage` to the latest version

TODO:
- [x] tests
- [x] Do we want to use `wp/` and `wp-gcs/`?
- [x] Do we want to use `isset($wp_version)`?